### PR TITLE
fix ExecJS::Runtimes.from_environment

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -58,13 +58,14 @@ module ExecJS
 
     def self.from_environment
       if name = ENV["EXECJS_RUNTIME"]
-        if runtime = const_get(name)
+        begin
+          runtime = const_get(name)
           if runtime.available?
-            runtime if runtime.available?
+            runtime
           else
             raise RuntimeUnavailable, "#{runtime.name} runtime is not available on this system"
           end
-        elsif !name.empty?
+        rescue
           raise RuntimeUnavailable, "#{name} runtime is not defined"
         end
       end


### PR DESCRIPTION
port of sstephenson/execjs#156

The current implementation of `ExecJS::Runtimes.from_environment` has two bad things:

1. The [`elsif` branch](https://github.com/rails/execjs/blob/master/lib/execjs/runtimes.rb#L61) can never reached, while the [`if const_get`](https://github.com/rails/execjs/blob/master/lib/execjs/runtimes.rb#L55) will raise a exception. So we should fix it by using a rescue.

2. There is a [doubled `if`](https://github.com/rails/execjs/blob/master/lib/execjs/runtimes.rb#L56-L57)