### PR TITLE
use constants in runtimes for listing

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -69,14 +69,7 @@ module ExecJS
     end
 
     def self.runtimes
-      @runtimes ||= [
-        RubyRacer,
-        RubyRhino,
-        JavaScriptCore,
-        Node,
-        SpiderMonkey,
-        JScript
-      ]
+      @runtimes ||= constants.map { |const| const_get(const) }
     end
   end
 


### PR DESCRIPTION
port of sstephenson/execjs#157

`ExecJS::Runtimes.runtimes` list all Runtimes explicit, `.name` read them form `.constants`, `.runtimes` should do the same.