### PR TITLE
simplify the implementation of Runtime.names

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -71,7 +71,7 @@ module ExecJS
     end
 
     def self.names
-      @names ||= constants.inject({}) { |h, name| h.merge(const_get(name) => name) }.values
+      @names ||= constants
     end
 
     def self.runtimes


### PR DESCRIPTION
port of sstephenson/execjs#158

I think the implementation of `Runtime.names` doesn't make any sense. Returning the value of `constants` do the same.