### PR TITLE
jRuby support

### DIFF
--- a/execjs.gemspec
+++ b/execjs.gemspec
@@ -18,5 +18,10 @@ Gem::Specification.new do |s|
   s.authors = ["Sam Stephenson", "Josh Peek"]
   s.email   = ["sstephenson@gmail.com", "josh@joshpeek.com"]
 
-  s.required_ruby_version = '>= 2.0.0'
+  case RUBY_ENGINE
+    when 'jruby'
+      s.required_ruby_version = '>= 1.7.16'
+    else
+      s.required_ruby_version = '>= 2.0.0'
+  end
 end


### PR DESCRIPTION
I can't install execjs 2.5.1 on jruby (1.7.16 in my case). 2.5.0 installs without a problem.
I don't think, that there is a huge difference between 2.5.0 and 2.5.1, so here is a small patch to gemspec.