### PR TITLE
Add direct V8 support (via `d3`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 cache: bundler
 sudo: false
 
+before_install:
+  - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew update; fi
+  - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew install v8; fi
 script: bundle exec ruby test/test_execjs.rb
 
 matrix:
@@ -40,3 +43,5 @@ matrix:
       env: EXECJS_RUNTIME=Duktape
     - os: osx
       env: EXECJS_RUNTIME=RubyRacer
+    - os: osx
+      env: EXECJS_RUNTIME=V8

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ExecJS supports these runtimes:
 * [Node.js](http://nodejs.org/)
 * Apple JavaScriptCore - Included with Mac OS X
 * [Microsoft Windows Script Host](http://msdn.microsoft.com/en-us/library/9bbdkx3k.aspx) (JScript)
+* [Google V8](http://code.google.com/p/v8/)
 
 A short example:
 

--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -42,6 +42,13 @@ module ExecJS
       encoding:    'UTF-16LE' # CScript with //U returns UTF-16LE
     )
 
+    V8 = ExternalRuntime.new(
+      name:        "V8",
+      command:     "d8",
+      runner_path: ExecJS.root + "/support/v8_runner.js",
+      encoding:    'UTF-8'
+    )
+
 
     def self.autodetect
       from_environment || best_available ||
@@ -75,7 +82,8 @@ module ExecJS
         Node,
         JavaScriptCore,
         SpiderMonkey,
-        JScript
+        JScript,
+        V8
       ]
     end
   end

--- a/lib/execjs/support/v8_runner.js
+++ b/lib/execjs/support/v8_runner.js
@@ -1,0 +1,18 @@
+(function(program, execJS) { execJS(program) })(function() { #{source}
+}, function(program) {
+  var output;
+  try {
+    result = program();
+    if (typeof result == 'undefined' && result !== null) {
+      print('["ok"]');
+    } else {
+      try {
+        print(JSON.stringify(['ok', result]));
+      } catch (err) {
+        print(JSON.stringify(['err', '' + err, err.stack]));
+      }
+    }
+  } catch (err) {
+    print(JSON.stringify(['err', '' + err, err.stack]));
+  }
+});


### PR DESCRIPTION
`rake test` passes here with v8-4.5.103.29 on Mac OS X.
It also should be added to travis, but I'm not really sure how it should be done (plain `sudo apt-get install v8` in `before_install` or somewhat else).