### PR TITLE
Whitespace in Windows Path results in binaries not being located

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -124,7 +124,7 @@ module ExecJS
         commands = Array(command)
         if ExecJS.windows? && File.extname(command) == ""
           ENV['PATHEXT'].split(File::PATH_SEPARATOR).each { |p|
-            commands << (command + p)
+            commands << (command + p.strip)
           }
         end
 
@@ -133,7 +133,7 @@ module ExecJS
             cmd
           else
             path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |p|
-              full_path = File.join(p, cmd)
+              full_path = File.join(p.strip, cmd)
               File.executable?(full_path) && File.file?(full_path)
             }
             path && File.expand_path(cmd, path)


### PR DESCRIPTION
I found that when configuring to use NodeJS on windows binaries were not being located due to path containing spaces. Please accept this pull request which strips the whitespace from the paths found in windows.

Thanks,