### PR TITLE
support for `jjs` runtime (available with Java 8+)

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -49,6 +49,12 @@ module ExecJS
       encoding:    'UTF-8'
     )
 
+    JJS = ExternalRuntime.new(
+      name:        "Nashorn (Java)",
+      command:     ["jjs"] + ( ENV['JAVA_HOME'] ? [ "#{ENV['JAVA_HOME']}/bin/jjs" ] : [] ),
+      runner_path: ExecJS.root + "/support/jjs_runner.js",
+      encoding:    'UTF-8'
+    )
 
     def self.autodetect
       from_environment || best_available ||
@@ -83,7 +89,8 @@ module ExecJS
         JavaScriptCore,
         SpiderMonkey,
         JScript,
-        V8
+        V8,
+        JJS
       ]
     end
   end

--- a/lib/execjs/support/jjs_runner.js
+++ b/lib/execjs/support/jjs_runner.js
@@ -1,0 +1,18 @@
+(function(program, execJS) { execJS(program) })(function() { #{source}
+}, function(program) {
+  var output;
+  try {
+    result = program();
+    if (typeof result == 'undefined' && result !== null) {
+      print('["ok"]');
+    } else {
+      try {
+        print(JSON.stringify(['ok', result]));
+      } catch (err) {
+        print(JSON.stringify(['err', '' + err, err.stack]));
+      }
+    }
+  } catch (err) {
+    print(JSON.stringify(['err', '' + err, err.stack]));
+  }
+});


### PR DESCRIPTION
`jjs` is a slower but very decent fall-back (ES5.1/ES6t) when nothing else is available.

it is available with recent Java 8. this should be beneficial for all but of course esp. for JRuby users in a container/minimal dep. world as it only requires them to install a JRE.