### PR TITLE
Allow for runtime specific option flags

### DIFF
--- a/lib/execjs/disabled_runtime.rb
+++ b/lib/execjs/disabled_runtime.rb
@@ -6,15 +6,15 @@ module ExecJS
       "Disabled"
     end
 
-    def exec(source)
+    def exec(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
-    def eval(source)
+    def eval(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
-    def compile(source)
+    def compile(source, options = {})
       raise Error, "ExecJS disabled"
     end
 

--- a/lib/execjs/duktape_runtime.rb
+++ b/lib/execjs/duktape_runtime.rb
@@ -4,7 +4,7 @@ require "json"
 module ExecJS
   class DuktapeRuntime < Runtime
     class Context < Runtime::Context
-      def initialize(runtime, source = "")
+      def initialize(runtime, source = "", options = {})
         @ctx = Duktape::Context.new(complex_object: nil)
         @ctx.exec_string(encode(source), '(execjs)')
       rescue Exception => e

--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -4,7 +4,7 @@ require "execjs/runtime"
 module ExecJS
   class ExternalRuntime < Runtime
     class Context < Runtime::Context
-      def initialize(runtime, source = "")
+      def initialize(runtime, source = "", options = {})
         source = encode(source)
 
         @runtime = runtime

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -15,16 +15,16 @@ module ExecJS
       @runtime = runtime
     end
 
-    def exec(source)
-      runtime.exec(source)
+    def exec(source, options = {})
+      runtime.exec(source, options)
     end
 
-    def eval(source)
-      runtime.eval(source)
+    def eval(source, options = {})
+      runtime.eval(source, options)
     end
 
-    def compile(source)
-      runtime.compile(source)
+    def compile(source, options = {})
+      runtime.compile(source, options)
     end
 
     def root

--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -3,7 +3,7 @@ require "execjs/runtime"
 module ExecJS
   class RubyRacerRuntime < Runtime
     class Context < Runtime::Context
-      def initialize(runtime, source = "")
+      def initialize(runtime, source = "", options = {})
         source = encode(source)
 
         lock do

--- a/lib/execjs/ruby_rhino_runtime.rb
+++ b/lib/execjs/ruby_rhino_runtime.rb
@@ -3,7 +3,7 @@ require "execjs/runtime"
 module ExecJS
   class RubyRhinoRuntime < Runtime
     class Context < Runtime::Context
-      def initialize(runtime, source = "")
+      def initialize(runtime, source = "", options = {})
         source = encode(source)
 
         @rhino_context = ::Rhino::Context.new

--- a/lib/execjs/runtime.rb
+++ b/lib/execjs/runtime.rb
@@ -6,7 +6,7 @@ module ExecJS
     class Context
       include Encoding
 
-      def initialize(runtime, source = "")
+      def initialize(runtime, source = "", options = {})
       end
 
       def exec(source, options = {})
@@ -30,18 +30,18 @@ module ExecJS
       self.class::Context
     end
 
-    def exec(source)
+    def exec(source, options = {})
       context = context_class.new(self)
-      context.exec(source)
+      context.exec(source, options)
     end
 
-    def eval(source)
+    def eval(source, options = {})
       context = context_class.new(self)
-      context.eval(source)
+      context.eval(source, options)
     end
 
-    def compile(source)
-      context_class.new(self, source)
+    def compile(source, options = {})
+      context_class.new(self, source, options)
     end
 
     def deprecated?

--- a/lib/execjs/runtime.rb
+++ b/lib/execjs/runtime.rb
@@ -31,17 +31,31 @@ module ExecJS
     end
 
     def exec(source, options = {})
-      context = context_class.new(self)
-      context.exec(source, options)
+      context = compile("", options)
+
+      if context.method(:exec).arity == 1
+        context.exec(source)
+      else
+        context.exec(source, options)
+      end
     end
 
     def eval(source, options = {})
-      context = context_class.new(self)
-      context.eval(source, options)
+      context = compile("", options)
+
+      if context.method(:eval).arity == 1
+        context.eval(source)
+      else
+        context.eval(source, options)
+      end
     end
 
     def compile(source, options = {})
-      context_class.new(self, source, options)
+      if context_class.instance_method(:initialize).arity == 2
+        context_class.new(self, source)
+      else
+        context_class.new(self, source, options)
+      end
     end
 
     def deprecated?

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -139,6 +139,15 @@ class TestExecJS < Test
     end
   end
 
+  def test_additional_options
+    assert ExecJS.eval("true", :foo => true)
+    assert ExecJS.exec("return true", :foo => true)
+
+    context = ExecJS.compile("foo = true", :foo => true)
+    assert context.eval("foo", :foo => true)
+    assert context.exec("return foo", :foo => true)
+  end
+
   def test_eval_blank
     assert_nil ExecJS.eval("")
     assert_nil ExecJS.eval(" ")


### PR DESCRIPTION
An `options` hash is already part of the `Context` argument list, but isn't totally plumbed all the way through.

It'd be great if we passed the options all the way down. This would allow for implementation specific flags such as timeouts.

``` ruby
ExecJS.eval("superSlow()", timeout: 3)
```

-
CC: @rafaelfranca @guilleiguaran