### PR TITLE
RFC: (WIP) Improve error marshaling from JS to Ruby

### DIFF
--- a/lib/execjs/duktape_runtime.rb
+++ b/lib/execjs/duktape_runtime.rb
@@ -46,6 +46,7 @@ module ExecJS
             re = / \(line (\d+)\)$/
             lineno = e.message[re, 1] || 1
             error = klass.new(e.message.sub(re, ""))
+            error.metadata = {} # FIXME: has to be available upstream
             error.set_backtrace(["(execjs):#{lineno}"] + e.backtrace)
             error
           else

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -3,8 +3,17 @@ require "rbconfig"
 
 module ExecJS
   class Error           < ::StandardError; end
-  class RuntimeError              < Error; end
-  class ProgramError              < Error; end
+  
+  class RuntimeError < Error
+    # Stores the unmarshaled JavaScript error information if it was available (type, message etc.)
+    attr_accessor :metadata
+  end
+  
+  class ProgramError < Error
+    # Stores the unmarshaled JavaScript error information if it was available (type, message etc.)
+    attr_accessor :metadata
+  end
+  
   class RuntimeUnavailable < RuntimeError; end
 
   class << self

--- a/lib/execjs/support/encode_error.js
+++ b/lib/execjs/support/encode_error.js
@@ -1,0 +1,12 @@
+function encodeError(err) {
+  var errMeta = {type: typeof(err), name: null, message: '' + err, stack: null};
+  if (typeof(err) === 'object') {
+    // Copy "message" and "name" since those are standard attributes for an Error
+    if (typeof(err.name) !== 'undefined') errMeta.name = err.name;
+    if (typeof(err.message) !== 'undefined') errMeta.message = err.message;
+    if (typeof(err.stack) !== 'undefined') errMeta.stack = err.stack;
+    // Copy all of the other properties that are tacked on the Error itself
+    if (typeof(Object.assign) === 'function') Object.assign(errMeta, err);
+  }
+  return errMeta;
+};

--- a/lib/execjs/support/jsc_runner.js
+++ b/lib/execjs/support/jsc_runner.js
@@ -1,5 +1,6 @@
 (function(program, execJS) { execJS(program) })(function() { #{source}
 }, function(program) {
+  #{encode_error_source}
   var output;
   try {
     result = program();
@@ -9,10 +10,10 @@
       try {
         print(JSON.stringify(['ok', result]));
       } catch (err) {
-        print(JSON.stringify(['err', '' + err, err.stack]));
+        print(JSON.stringify(['err', encodeError(err)]));
       }
     }
   } catch (err) {
-    print(JSON.stringify(['err', '' + err, err.stack]));
+    print(JSON.stringify(['err', encodeError(err)]));
   }
 });

--- a/lib/execjs/support/jscript_runner.js
+++ b/lib/execjs/support/jscript_runner.js
@@ -2,6 +2,7 @@
   return eval(#{encode_source(source)});
 }, function(program) {
   #{json2_source}
+  #{encode_error_source}
   var output, print = function(string) {
     WScript.Echo(string);
   };
@@ -13,10 +14,10 @@
       try {
         print(JSON.stringify(['ok', result]));
       } catch (err) {
-        print(JSON.stringify(['err', err.name + ': ' + err.message, err.stack]));
+        print(JSON.stringify(['err', encodeError(err)]));
       }
     }
   } catch (err) {
-    print(JSON.stringify(['err', err.name + ': ' + err.message, err.stack]));
+    print(JSON.stringify(['err', encodeError(err)]));
   }
 });

--- a/lib/execjs/support/node_runner.js
+++ b/lib/execjs/support/node_runner.js
@@ -3,6 +3,7 @@
   var output, print = function(string) {
     process.stdout.write('' + string);
   };
+  #{encode_error_source}
   try {
     result = program();
     if (typeof result == 'undefined' && result !== null) {
@@ -11,10 +12,10 @@
       try {
         print(JSON.stringify(['ok', result]));
       } catch (err) {
-        print(JSON.stringify(['err', '' + err, err.stack]));
+        print(JSON.stringify(['err', encodeError(err)]));
       }
     }
   } catch (err) {
-    print(JSON.stringify(['err', '' + err, err.stack]));
+    print(JSON.stringify(['err', encodeError(err)]));
   }
 });

--- a/lib/execjs/support/spidermonkey_runner.js
+++ b/lib/execjs/support/spidermonkey_runner.js
@@ -1,5 +1,6 @@
 (function(program, execJS) { execJS(program) })(function() { #{source}
 }, function(program) {
+  #{encode_error_source}
   var output;
   try {
     result = program();
@@ -9,10 +10,10 @@
       try {
         print(JSON.stringify(['ok', result]));
       } catch (err) {
-        print(JSON.stringify(['err', '' + err, err.stack]));
+        print(JSON.stringify(['err', encodeError(err)]));
       }
     }
   } catch (err) {
-    print(JSON.stringify(['err', '' + err, err.stack]));
+    print(JSON.stringify(['err', encodeError(err)]));
   }
 });

--- a/lib/execjs/support/v8_runner.js
+++ b/lib/execjs/support/v8_runner.js
@@ -1,5 +1,6 @@
 (function(program, execJS) { execJS(program) })(function() { #{source}
 }, function(program) {
+  #{encode_error_source}
   var output;
   try {
     result = program();
@@ -9,10 +10,10 @@
       try {
         print(JSON.stringify(['ok', result]));
       } catch (err) {
-        print(JSON.stringify(['err', '' + err, err.stack]));
+        print(JSON.stringify(['err', encodeError(err)]));
       }
     }
   } catch (err) {
-    print(JSON.stringify(['err', '' + err, err.stack]));
+    print(JSON.stringify(['err', encodeError(err)]));
   }
 });


### PR DESCRIPTION
WIP - this is a request for feedback mostly and not finished.

I encountered a need to interface with a library that adds meaningful properties to a JS Error object when throwing. Thus came an idea of passing more meaningful error metadata to the runtime from the JS engine. The main change is that the error object caught during parsing/execution is converted to a plain JS object, and as much metadata as can be collected gets tacked onto it. The data is then available on the Ruby side in `Error#metadata` as a Hash. It is done using a conversion because I found that doing `JSON.stringify(err)` has really varying behaviors depending on the JS engine used.

The implementation I've made so far works with all the runtimes I could spin up at the moment on OSX 10.11 except for Duktape - it does not use a wrapper shim but executes via runtime handles. So if this has to work with Duktape I will need to look into adding error metadata to duktape.rb with Magnus. But if this goes out of scope for ExecJS (which I think it is not) then it's not really worth the effort I guess.

If this is accepted nothing should ideally change for consumer code, so this is a minor feature.

The library I need this for is https://code.google.com/archive/p/glsl-unit/ (somewhat abandonware but still working quite well). And they use a customized SyntaxError, and pass along the line and column from the parse error which is tremendously useful (and gets discarded if passed via string concatenation).