### PR TITLE
Add support for MiniRacer runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 pkg/*
+.bundle/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-sudo: false
+sudo: true
 # we need trust so correct gcc runs for mini_racer, latest v8 requires gcc 4.8+
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,5 @@ matrix:
       env: EXECJS_RUNTIME=RubyRacer
     - os: osx
       env: EXECJS_RUNTIME=V8
+    - os: osx
+      env: EXECJS_RUNTIME=MiniRacer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
 sudo: false
+# we need trust so correct gcc runs for mini_racer, latest v8 requires gcc 4.8+
+dist: trusty
 
 before_install:
   - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 before_install:
   - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew update; fi
   - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew install v8; fi
-script: bundle exec ruby test/test_execjs.rb
+script: bundle && bundle exec ruby test/test_execjs.rb
 
 matrix:
   include:
@@ -15,6 +15,8 @@ matrix:
       env: EXECJS_RUNTIME=Duktape
     - rvm: 2.0.0
       env: EXECJS_RUNTIME=RubyRacer
+    - rvm: 2.0.0
+      env: EXECJS_RUNTIME=MiniRacer
 
     - rvm: 2.1
       env: EXECJS_RUNTIME=Node
@@ -22,6 +24,8 @@ matrix:
       env: EXECJS_RUNTIME=Duktape
     - rvm: 2.1
       env: EXECJS_RUNTIME=RubyRacer
+    - rvm: 2.1
+      env: EXECJS_RUNTIME=MiniRacer
 
     - rvm: 2.2
       env: EXECJS_RUNTIME=Node
@@ -29,13 +33,17 @@ matrix:
       env: EXECJS_RUNTIME=Duktape
     - rvm: 2.2
       env: EXECJS_RUNTIME=RubyRacer
+    - rvm: 2.2
+      env: EXECJS_RUNTIME=MiniRacer
 
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: EXECJS_RUNTIME=Node
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: EXECJS_RUNTIME=Duktape
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: EXECJS_RUNTIME=RubyRacer
+    - rvm: 2.3.1
+      env: EXECJS_RUNTIME=MiniRacer
 
     - rvm: jruby-19mode
       env: EXECJS_RUNTIME=Node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 cache: bundler
-sudo: true
+sudo: false
 # we need trust so correct gcc runs for mini_racer, latest v8 requires gcc 4.8+
-dist: trusty
 
 before_install:
   - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew update; fi
@@ -20,6 +19,8 @@ matrix:
       env: EXECJS_RUNTIME=RubyRacer
     - rvm: 2.0.0
       env: EXECJS_RUNTIME=MiniRacer
+      dist: trusty
+      sudo: true
 
     - rvm: 2.1
       env: EXECJS_RUNTIME=Node
@@ -29,6 +30,8 @@ matrix:
       env: EXECJS_RUNTIME=RubyRacer
     - rvm: 2.1
       env: EXECJS_RUNTIME=MiniRacer
+      dist: trusty
+      sudo: true
 
     - rvm: 2.2
       env: EXECJS_RUNTIME=Node
@@ -38,6 +41,8 @@ matrix:
       env: EXECJS_RUNTIME=RubyRacer
     - rvm: 2.2
       env: EXECJS_RUNTIME=MiniRacer
+      dist: trusty
+      sudo: true
 
     - rvm: 2.3.1
       env: EXECJS_RUNTIME=Node
@@ -47,6 +52,8 @@ matrix:
       env: EXECJS_RUNTIME=RubyRacer
     - rvm: 2.3.1
       env: EXECJS_RUNTIME=MiniRacer
+      dist: trusty
+      sudo: true
 
     - rvm: jruby-19mode
       env: EXECJS_RUNTIME=Node
@@ -65,3 +72,4 @@ matrix:
       env: EXECJS_RUNTIME=V8
     - os: osx
       env: EXECJS_RUNTIME=MiniRacer
+      osx_image: xcode7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ dist: trusty
 before_install:
   - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew update; fi
   - if [ "$EXECJS_RUNTIME" == "V8" ]; then brew install v8; fi
+  - if [ "$EXECJS_RUNTIME" == "MiniRacer" ]; then gem install bundler -v 1.12.0; fi
 script: bundle && bundle exec ruby test/test_execjs.rb
 
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,11 @@ gemspec
 
 group :test do
   gem 'duktape', platform: :mri
-  gem 'therubyracer', platform: :mri
-  gem 'therubyrhino', ">=1.73.3", platform: :jruby
+  if ENV['EXECJS_RUNTIME'] == 'MiniRacer'
+     gem 'mini_racer', '0.1.0.beta.3', platform: :mri
+  else
+     gem 'therubyracer', platform: :mri
+  end
+  gem 'therubyrhino', '>=1.73.3', platform: :jruby
   gem 'minitest', require: false
-  gem 'mini_racer', platform: :mri
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :test do
   gem 'therubyracer', platform: :mri
   gem 'therubyrhino', ">=1.73.3", platform: :jruby
   gem 'minitest', require: false
+  gem 'mini_racer', platform: :mri
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :default => :test
 $:.unshift File.expand_path("../lib", __FILE__)
 require "execjs/runtimes"
 
-tests = namespace :test do |tests|
+namespace :test do |tests|
   ExecJS::Runtimes.names.each do |name|
     next if ExecJS::Runtimes.const_get(name).deprecated?
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :default => :test
 $:.unshift File.expand_path("../lib", __FILE__)
 require "execjs/runtimes"
 
-namespace :test do |tests|
+tests = namespace :test do |tests|
   ExecJS::Runtimes.names.each do |name|
     next if ExecJS::Runtimes.const_get(name).deprecated?
 

--- a/lib/execjs/mini_racer_runtime.rb
+++ b/lib/execjs/mini_racer_runtime.rb
@@ -3,7 +3,7 @@ require "execjs/runtime"
 module ExecJS
   class MiniRacerRuntime < Runtime
     class Context < Runtime::Context
-      def initialize(runtime, source = "")
+      def initialize(runtime, source = "", options={})
         source = encode(source)
         @context = ::MiniRacer::Context.new
         translate do

--- a/lib/execjs/mini_racer_runtime.rb
+++ b/lib/execjs/mini_racer_runtime.rb
@@ -1,0 +1,46 @@
+require "execjs/runtime"
+
+module ExecJS
+  class MiniRacerRuntime < Runtime
+    class Context < Runtime::Context
+      def initialize(runtime, source = "")
+        source = encode(source)
+        @context = ::MiniRacer::Context.new
+        @context.eval(source)
+      end
+
+      def exec(source, options = {})
+        source = encode(source)
+
+        if /\S/ =~ source
+          eval "(function(){#{source}})()"
+        end
+      end
+
+      def eval(source, options = {})
+        source = encode(source)
+
+        if /\S/ =~ source
+          @context.eval("(#{source})")
+        end
+      end
+
+      def call(identifier, *args)
+        # TODO optimise generate
+        eval "#{identifier}.apply(this, #{::JSON.generate(args)})"
+      end
+
+    end
+
+    def name
+      "mini_racer (V8)"
+    end
+
+    def available?
+      require "mini_racer"
+      true
+    rescue LoadError
+      false
+    end
+  end
+end

--- a/lib/execjs/mini_racer_runtime.rb
+++ b/lib/execjs/mini_racer_runtime.rb
@@ -6,7 +6,9 @@ module ExecJS
       def initialize(runtime, source = "")
         source = encode(source)
         @context = ::MiniRacer::Context.new
-        @context.eval(source)
+        translate do
+          @context.eval(source)
+        end
       end
 
       def exec(source, options = {})
@@ -21,13 +23,67 @@ module ExecJS
         source = encode(source)
 
         if /\S/ =~ source
-          @context.eval("(#{source})")
+          translate do
+            @context.eval("(#{source})")
+          end
         end
       end
 
       def call(identifier, *args)
         # TODO optimise generate
         eval "#{identifier}.apply(this, #{::JSON.generate(args)})"
+      end
+
+      private
+
+      def strip_functions!(value)
+        if Array === value
+          value.map! do |v|
+            if MiniRacer::JavaScriptFunction === value
+              nil
+            else
+              strip_functions!(v)
+            end
+          end
+        elsif Hash === value
+          value.each do |k,v|
+            if MiniRacer::JavaScriptFunction === v
+              value.delete k
+            else
+              value[k] = strip_functions!(v)
+            end
+          end
+          value
+        elsif MiniRacer::JavaScriptFunction === value
+          nil
+        else
+          value
+        end
+      end
+
+      def translate
+        begin
+          strip_functions! yield
+        rescue MiniRacer::RuntimeError => e
+          ex = ProgramError.new e.message
+          if backtrace = e.backtrace
+            backtrace = backtrace.map { |line|
+              if line =~ /JavaScript at/
+                line.sub("JavaScript at ", "")
+                    .sub("<anonymous>", "(execjs)")
+                    .strip
+              else
+                line
+              end
+            }
+            ex.set_backtrace backtrace
+          end
+          raise ex
+        rescue MiniRacer::ParseError => e
+          ex = RuntimeError.new e.message
+          ex.set_backtrace(["(execjs):1"] + e.backtrace)
+          raise ex
+        end
       end
 
     end

--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -4,6 +4,7 @@ require "execjs/duktape_runtime"
 require "execjs/external_runtime"
 require "execjs/ruby_racer_runtime"
 require "execjs/ruby_rhino_runtime"
+require "execjs/mini_racer_runtime"
 
 module ExecJS
   module Runtimes
@@ -14,6 +15,8 @@ module ExecJS
     RubyRacer = RubyRacerRuntime.new
 
     RubyRhino = RubyRhinoRuntime.new
+
+    MiniRacer = MiniRacerRuntime.new
 
     Node = ExternalRuntime.new(
       name:        "Node.js (V8)",
@@ -79,6 +82,7 @@ module ExecJS
         RubyRacer,
         RubyRhino,
         Duktape,
+        MiniRacer,
         Node,
         JavaScriptCore,
         SpiderMonkey,


### PR DESCRIPTION
**Do not merge yet**

See: 

https://github.com/SamSaffron/mini_racer

This PR introduces a mini_racer runtime, all tests pass, however there is a big hurdle testing wise that we need to resolve.

therubyracer now depends on libv8 version `3.16.xx`

mini_racer depends on libv8 `5.0.xx` 

this means that test:all is going to have to spawn multiple process to run the tests, it also means the Gemfile.lock is going to need a bunch of fussing with.

mini_racer is still not released, it is waiting on libv8 `5.0.xx` to be released, once that is done the gem can go out, I have done quite a bit of testing on it, including running it through valgrind https://github.com/SamSaffron/mini_racer/blob/master/Rakefile#L32-L52

cc @cowboyd @ignisf