### PR TITLE
Fixes Node.js compilers writing to STDOUT and/or STDERR during compilation

### DIFF
--- a/lib/execjs/support/node_runner.js
+++ b/lib/execjs/support/node_runner.js
@@ -4,7 +4,16 @@
     process.stdout.write('' + string);
   };
   try {
+    var stdoutWrite = process.stdout.write;
+    var stderrWrite = process.stderr.write;
+
+    process.stdout.write = process.stderr.write = function () {}
+
     result = program();
+
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+
     if (typeof result == 'undefined' && result !== null) {
       print('["ok"]');
     } else {

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -376,4 +376,20 @@ class TestExecJS < Test
     assert_equal "function foo(bar){return bar}",
       context.call("uglify", "function foo(bar) {\n  return bar;\n}")
   end
+
+  def test_node_runtime_with_compiler_writing_to_stdio
+    skip if not ExecJS.runtime.name =~ /Node/
+
+    source = <<-JS
+      process.stdout.write('WARNING');
+      process.stderr.write('ERROR');
+
+      function compile(code) {
+        return code;
+      }
+    JS
+
+    context = ExecJS.compile(source)
+    assert_equal "foo()", context.call("compile", "foo()")
+  end
 end


### PR DESCRIPTION
This was happening when I was trying to compiler an Ember template with Rails Assets that had deprecation warnings. The warnings would be printed to STDOUT and end up being part of the string that was going to be JSON parsed.
