### PR TITLE
Undefine globals, not just shadow

### DIFF
--- a/lib/execjs/support/jsc_runner.js
+++ b/lib/execjs/support/jsc_runner.js
@@ -2,6 +2,7 @@
 }, function(program) {
   var output;
   try {
+    delete this.console;
     result = program();
     if (typeof result == 'undefined' && result !== null) {
       print('["ok"]');

--- a/lib/execjs/support/node_runner.js
+++ b/lib/execjs/support/node_runner.js
@@ -4,7 +4,17 @@
     process.stdout.write('' + string);
   };
   try {
+    var __process__ = process;
+    delete this.process;
+    delete this.console;
+    delete this.setTimeout;
+    delete this.setInterval;
+    delete this.clearTimeout;
+    delete this.clearInterval;
+    delete this.setImmediate;
+    delete this.clearImmediate;
     result = program();
+    this.process = __process__;
     if (typeof result == 'undefined' && result !== null) {
       print('["ok"]');
     } else {
@@ -15,6 +25,7 @@
       }
     }
   } catch (err) {
+    this.process = __process__;
     print(JSON.stringify(['err', '' + err, err.stack]));
   }
 });

--- a/lib/execjs/support/node_runner.js
+++ b/lib/execjs/support/node_runner.js
@@ -1,4 +1,4 @@
-(function(program, execJS) { execJS(program) })(function(global, module, exports, require, console, setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate) { #{source}
+(function(program, execJS) { execJS(program) })(function(global, process, module, exports, require, console, setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate) { #{source}
 }, function(program) {
   var output, print = function(string) {
     process.stdout.write('' + string);

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -237,6 +237,10 @@ class TestExecJS < Test
     assert ExecJS.eval("typeof global == 'undefined'")
   end
 
+  def test_node_process_is_undefined
+    assert ExecJS.eval("typeof process == 'undefined'")
+  end
+
   def test_commonjs_vars_are_undefined
     assert ExecJS.eval("typeof module == 'undefined'")
     assert ExecJS.eval("typeof exports == 'undefined'")

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -239,16 +239,22 @@ class TestExecJS < Test
 
   def test_node_process_is_undefined
     assert ExecJS.eval("typeof process == 'undefined'")
+    refute ExecJS.eval("'process' in this")
   end
 
   def test_commonjs_vars_are_undefined
     assert ExecJS.eval("typeof module == 'undefined'")
     assert ExecJS.eval("typeof exports == 'undefined'")
     assert ExecJS.eval("typeof require == 'undefined'")
+
+    refute ExecJS.eval("'module' in this")
+    refute ExecJS.eval("'exports' in this")
+    refute ExecJS.eval("'require' in this")
   end
 
   def test_console_is_undefined
     assert ExecJS.eval("typeof console == 'undefined'")
+    refute ExecJS.eval("'console' in this")
   end
 
   def test_timers_are_undefined
@@ -258,6 +264,13 @@ class TestExecJS < Test
     assert ExecJS.eval("typeof clearInterval == 'undefined'")
     assert ExecJS.eval("typeof setImmediate == 'undefined'")
     assert ExecJS.eval("typeof clearImmediate == 'undefined'")
+
+    refute ExecJS.eval("'setTimeout' in this")
+    refute ExecJS.eval("'setInterval' in this")
+    refute ExecJS.eval("'clearTimeout' in this")
+    refute ExecJS.eval("'clearInterval' in this")
+    refute ExecJS.eval("'setImmediate' in this")
+    refute ExecJS.eval("'clearImmediate' in this")
   end
 
   def test_compile_large_scripts


### PR DESCRIPTION
Shadowed globals maybe also accessed via `this.console`. This normalizes these globals across all runners. See FAQ (https://github.com/rails/execjs#faq) for why these globals should not be exposed during evaluation.

Related #42.