### PR TITLE
Support complex context in Duktape by using eval

### DIFF
--- a/lib/execjs/duktape_runtime.rb
+++ b/lib/execjs/duktape_runtime.rb
@@ -26,9 +26,7 @@ module ExecJS
       end
 
       def call(identifier, *args)
-        @ctx.call_prop(identifier.split("."), *args)
-      rescue Exception => e
-        raise wrap_error(e)
+        eval "#{identifier}.apply(this, #{::JSON.generate(args)})"
       end
 
       private


### PR DESCRIPTION
Just like `ExecJS::ExternalRuntime::Context#call`, not using Duktape's `#call_prop` but simple `eval` will solve #45 .

I don't know if there might be any side effects for this change, but it seems working.