### PR TITLE
Fix for empty EXECJS_RUNTIME

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -64,7 +64,9 @@ module ExecJS
     end
 
     def self.from_environment
-      if name = ENV["EXECJS_RUNTIME"]
+      env = ENV["EXECJS_RUNTIME"]
+      if env && !env.empty?
+        name = env
         raise RuntimeUnavailable, "#{name} runtime is not defined" unless const_defined?(name)
         runtime = const_get(name)
 


### PR DESCRIPTION
I had [problem in AutoprefixerRails](https://travis-ci.org/ai/autoprefixer-rails/jobs/279410685) when I set `EXECJS_RUNTIME=` (empty value).

I set the [empty value](https://github.com/ai/autoprefixer-rails/blob/91bcfcda9f9ffc7cdb9c1b11c84db1496a8c7939/.travis.yml#L20) to override previous value for tests.

@rafaelfranca what do you think about this fix?