### PR TITLE
Search `node` binary first even when `nodejs` exists

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -20,7 +20,7 @@ module ExecJS
 
     Node = ExternalRuntime.new(
       name:        "Node.js (V8)",
-      command:     ["nodejs", "node"],
+      command:     ["node", "nodejs"],
       runner_path: ExecJS.root + "/support/node_runner.js",
       encoding:    'UTF-8'
     )


### PR DESCRIPTION
Many of node.js managers like [nodebrew](https://github.com/hokaccha/nodebrew) install `node` command.
OTOH OS package managers often install `nodejs` too, e.g. Debian/Ubuntu.

* ref: https://packages.debian.org/sid/amd64/nodejs/filelist

Thus, if OS has installed older version of `nodejs`, execjs detects and uses this preferentially. This makes trouble when libraries we use requires newer node.js runtime(e.g. [autoprefixer](https://github.com/postcss/autoprefixer)).