### PR TITLE
Add test for passing Symbol to JS and fix it for GraalJSRuntime

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -1,5 +1,6 @@
-require "tmpdir"
 require "execjs/runtime"
+require "tmpdir"
+require "json"
 
 module ExecJS
   class ExternalRuntime < Runtime

--- a/lib/execjs/graaljs_runtime.rb
+++ b/lib/execjs/graaljs_runtime.rb
@@ -96,6 +96,8 @@ module ExecJS
         case value
         when nil, true, false, Integer, Float, String
           value
+        when Symbol
+          value.to_s
         when Array
           value.map { |e| convert_ruby_to_js(e) }
         when Hash

--- a/lib/execjs/ruby_rhino_runtime.rb
+++ b/lib/execjs/ruby_rhino_runtime.rb
@@ -1,4 +1,5 @@
 require "execjs/runtime"
+require "json"
 
 module ExecJS
   class RubyRhinoRuntime < Runtime
@@ -32,7 +33,11 @@ module ExecJS
       end
 
       def call(properties, *args)
-        unbox @rhino_context.eval(properties).call(*args)
+        # Might no longer be necessary if therubyrhino handles Symbols directly:
+        # https://github.com/rubyjs/therubyrhino/issues/43
+        converted_args = JSON.parse(JSON.generate(args), create_additions: false)
+
+        unbox @rhino_context.eval(properties).call(*converted_args)
       rescue Exception => e
         raise wrap_error(e)
       end

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -167,6 +167,13 @@ class TestExecJS < Test
     end
   end
 
+  def test_symbol
+    context = ExecJS.compile("function echo(test) { return test; }")
+    assert_equal "symbol", context.call("echo", :symbol)
+    assert_equal ["symbol"], context.call("echo", [:symbol])
+    assert_equal({"key" => "value"}, context.call("echo", {key: :value}))
+  end
+
   def test_additional_options
     assert ExecJS.eval("true", :foo => true)
     assert ExecJS.exec("return true", :foo => true)


### PR DESCRIPTION
@byroot Could you review and merge? :)

@bjfish noticed `barber` and/or Discourse is relying on this.

For curiosity I also tried what happens if we pass `Object.new` to JS and on miniracer & node it just passes it as a String with `.to_s` like `JSON.dump` does (e.g. `"#<Object:0x0000000001d05718>"`). On duktape it gives `TypeError: cannot convert Object` and on the Graal.js backend it gives `TypeError: Unknown how to convert to JS: #<Object:0x1ad8>`.
I think the TypeError is good there, JSON just using `to_s` seems rather unexpected in general, so I think let's keep that as-is.