### PR TITLE
Improve `Encoding` handling

### DIFF
--- a/lib/execjs/encoding.rb
+++ b/lib/execjs/encoding.rb
@@ -5,15 +5,15 @@ module ExecJS
       # workaround for jruby bug http://jira.codehaus.org/browse/JRUBY-6588
       # workaround for rbx bug https://github.com/rubinius/rubinius/issues/1729
       def encode(string)
-        if string.encoding.name == 'ASCII-8BIT'
+        if string.encoding == ::Encoding::BINARY
           data = string.dup
-          data.force_encoding('UTF-8')
+          data.force_encoding(::Encoding::UTF_8)
 
           unless data.valid_encoding?
-            raise ::Encoding::UndefinedConversionError, "Could not encode ASCII-8BIT data #{string.dump} as UTF-8"
+            raise ::Encoding::UndefinedConversionError, "Could not encode binary data #{string.dump} as UTF-8"
           end
         else
-          data = string.encode('UTF-8')
+          data = string.encode(::Encoding::UTF_8)
         end
         data
       end


### PR DESCRIPTION
Comparing the Encoding instance directly is more efficient.

Also `ASCII-8BIT` may be renamed in 3.2: https://bugs.ruby-lang.org/issues/18576