### PR TITLE
Adapt ExecJS::GraalJSRuntime to foreign exception changes in TruffleRuby

### DIFF
--- a/lib/execjs/graaljs_runtime.rb
+++ b/lib/execjs/graaljs_runtime.rb
@@ -46,16 +46,18 @@ module ExecJS
 
       private
 
+      ForeignException = defined?(Polyglot::ForeignException) ? Polyglot::ForeignException : ::RuntimeError
+
       def translate
         convert_js_to_ruby yield
-      rescue ::RuntimeError => e
+      rescue ForeignException => e
         if e.message.start_with?('SyntaxError:')
           error_class = ExecJS::RuntimeError
         else
           error_class = ExecJS::ProgramError
         end
 
-        backtrace = e.backtrace.map { |line| line.sub('(eval)', '(execjs)') }
+        backtrace = (e.backtrace || []).map { |line| line.sub('(eval)', '(execjs)') }
         raise error_class, e.message, backtrace
       end
 


### PR DESCRIPTION
* Foreign exceptions are no longer translated to ::RuntimeError but
  remain as foreign exceptions and are given the class Polyglot::ForeignException.
* The backtrace can be nil, notably when throwing a JS string.

cc @byroot