### PR TITLE
Convert Symbol explicitly to a JS String and add test

### DIFF
--- a/lib/execjs/graaljs_runtime.rb
+++ b/lib/execjs/graaljs_runtime.rb
@@ -98,10 +98,8 @@ module ExecJS
         case value
         when nil, true, false, Integer, Float
           value
-        when String
+        when String, Symbol
           Truffle::Interop.as_truffle_string value
-        when Symbol
-          value.to_s
         when Array
           value.map { |e| convert_ruby_to_js(e) }
         when Hash

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -172,6 +172,9 @@ class TestExecJS < Test
     assert_equal "symbol", context.call("echo", :symbol)
     assert_equal ["symbol"], context.call("echo", [:symbol])
     assert_equal({"key" => "value"}, context.call("echo", {key: :value}))
+
+    context = ExecJS.compile("function myslice(str) { return str.slice(1); }")
+    assert_equal "ymbol", context.call("myslice", :symbol)
   end
 
   def test_additional_options


### PR DESCRIPTION
A follow-up of #115, somehow I missed that Symbol should be treated the same as String.

The added test fails without the fix (because it ends up calling Ruby's `String#slice` and not JS's `String.prototype.slice()`), and passes with the fix.

cc FYI @bjfish