### PR TITLE
Update URL to mini_racer GH repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ExecJS supports these runtimes:
 * Apple JavaScriptCore - Included with Mac OS X
 * [Microsoft Windows Script Host](http://msdn.microsoft.com/en-us/library/9bbdkx3k.aspx) (JScript)
 * [Google V8](http://code.google.com/p/v8/)
-* [mini_racer](https://github.com/discourse/mini_racer) - Google V8
+* [mini_racer](https://github.com/rubyjs/mini_racer) - Google V8
   embedded within Ruby
 * [GraalVM JavaScript](https://www.graalvm.org/javascript/) - used on TruffleRuby
 


### PR DESCRIPTION
`discourse/mini_racer` -> `rubyjs/mini_racer`

Don't know when, but mini_racer lives at https://github.com/rubyjs/mini_racer