### PR TITLE
CI against stable version of truffleruby+graalvm (22.3.1) for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '2.7', '2.6', '2.5', 'jruby', 'truffleruby', 'truffleruby+graalvm' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', 'jruby', 'truffleruby', 'truffleruby+graalvm-22.3.1' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
because truffleruby+graalvm 23.0.0-preview1 aborts with `gu: command not found` https://github.com/rails/execjs/actions/runs/5142014882/jobs/9255214275
/cc @eregon 