### PR TITLE
Updates for TruffleRuby 23.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', 'jruby', 'truffleruby', 'truffleruby+graalvm-22.3.1' ]
+        ruby: [ '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', 'jruby', 'truffleruby', 'truffleruby+graalvm' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,8 +32,8 @@ jobs:
       - name: Set TRUFFLERUBYOPT
         run: echo "TRUFFLERUBYOPT=--jvm --polyglot" >> $GITHUB_ENV
         if: startsWith(matrix.ruby, 'truffleruby+graalvm')
-      - name: Install GraalVM js component
-        run: if ! gu list | grep '^js '; then gu install js; fi
+      - name: Install GraalJS
+        run: truffleruby-polyglot-get js
         if: startsWith(matrix.ruby, 'truffleruby+graalvm')
 
       - name: Run test

--- a/lib/execjs/graaljs_runtime.rb
+++ b/lib/execjs/graaljs_runtime.rb
@@ -136,8 +136,7 @@ module ExecJS
 
       unless Polyglot.languages.include? "js"
         warn "The language 'js' is not available, you likely need to `export TRUFFLERUBYOPT='--jvm --polyglot'`", uplevel: 0 if $VERBOSE
-        warn "You also need to install the 'js' component with 'gu install js' on GraalVM 22.2+", uplevel: 0 if $VERBOSE
-        warn "Note that you need TruffleRuby+GraalVM and not just the TruffleRuby standalone to use #{self.class}", uplevel: 0 if $VERBOSE
+        warn "You also need to install the 'js' component, see https://github.com/oracle/truffleruby/blob/master/doc/user/polyglot.md#installing-other-languages", uplevel: 0 if $VERBOSE
         return @available = false
       end
 


### PR DESCRIPTION
The way to install GraalJS changed, and this is now documented in TruffleRuby docs.