### PR TITLE
Add async/await & promise support to Bun runner

### DIFF
--- a/lib/execjs/support/bun_runner.js
+++ b/lib/execjs/support/bun_runner.js
@@ -1,4 +1,4 @@
-(function(program, execJS) { (function() {execJS(program) }).call({}); })(function(self, global, process, module, exports, require, console, setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate) { #{source}
+(function(program, execJS) { (function() {execJS(program) }).call({}); })(async function(self, global, process, module, exports, require, console, setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate) { #{source}
 }, function(program) {
   // Force BunJS to use sloppy mode see https://github.com/oven-sh/bun/issues/4527#issuecomment-1709520894
   exports.abc = function(){}
@@ -11,17 +11,21 @@
   try {
     delete this.process;
     delete this.console;
-    result = program();
-    process = __process__;
-    if (typeof result == 'undefined' && result !== null) {
-      printFinal('["ok"]');
-    } else {
-      try {
-        printFinal(JSON.stringify(['ok', result]));
-      } catch (err) {
-        printFinal(JSON.stringify(['err', '' + err, err.stack]));
+    (program()).then((result) => {
+      process = __process__;
+      if (typeof result == 'undefined' && result !== null) {
+        printFinal('["ok"]');
+      } else {
+        try {
+          printFinal(JSON.stringify(['ok', result]));
+        } catch (err) {
+          printFinal(JSON.stringify(['err', '' + err, err.stack]));
+        }
       }
-    }
+    }).catch((err) => {
+      process = __process__;
+      printFinal(JSON.stringify(['err', '' + err, err.stack]));
+    })
   } catch (err) {
     process = __process__;
     printFinal(JSON.stringify(['err', '' + err, err.stack]));

--- a/lib/execjs/support/bun_runner.js
+++ b/lib/execjs/support/bun_runner.js
@@ -1,5 +1,5 @@
 (function(program, execJS) { (function() {execJS(program) }).call({}); })(async function(self, global, process, module, exports, require, console, setTimeout, setInterval, clearTimeout, clearInterval, setImmediate, clearImmediate) { #{source}
-}, function(program) {
+}, async function(program) {
   // Force BunJS to use sloppy mode see https://github.com/oven-sh/bun/issues/4527#issuecomment-1709520894
   exports.abc = function(){}
   var __process__ = process;
@@ -11,21 +11,17 @@
   try {
     delete this.process;
     delete this.console;
-    (program()).then((result) => {
-      process = __process__;
-      if (typeof result == 'undefined' && result !== null) {
-        printFinal('["ok"]');
-      } else {
-        try {
-          printFinal(JSON.stringify(['ok', result]));
-        } catch (err) {
-          printFinal(JSON.stringify(['err', '' + err, err.stack]));
-        }
+    result = await program();
+    process = __process__;
+    if (typeof result == 'undefined' && result !== null) {
+      printFinal('["ok"]');
+    } else {
+      try {
+        printFinal(JSON.stringify(['ok', result]));
+      } catch (err) {
+        printFinal(JSON.stringify(['err', '' + err, err.stack]));
       }
-    }).catch((err) => {
-      process = __process__;
-      printFinal(JSON.stringify(['err', '' + err, err.stack]));
-    })
+    }
   } catch (err) {
     process = __process__;
     printFinal(JSON.stringify(['err', '' + err, err.stack]));

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -450,6 +450,15 @@ class TestExecJS < Test
       context.call("uglify", "function foo(bar) {\n  return bar;\n}")
   end
 
+  def test_async_bun
+    skip unless ENV["EXECJS_RUNTIME"] == "Bun"
+    source = <<-JS
+      async function testAsync() { return (await new Promise((resolve) => { resolve("it works!") } )) }
+    JS
+    context = ExecJS.compile(source)
+    assert_equal "it works!", context.call("testAsync")
+  end
+
   private
 
     def assert_output(expected, actual)


### PR DESCRIPTION
This PR adds support for async/await and promises for the Bun runner. 

This allows for importing libraries using dynamic imports:

```
const Plot = await import("@observablehq/plot")
```