### PR TITLE
Use Bun.write(Bun.stdout, '') for output in Bun executor

### DIFF
--- a/lib/execjs/support/bun_runner.js
+++ b/lib/execjs/support/bun_runner.js
@@ -4,7 +4,7 @@
   exports.abc = function(){}
   var __process__ = process;
   var printFinal = function(string) {
-    process.stdout.write('' + string, function() {
+    Bun.write(Bun.stdout, '' + string).then(function() {
       __process__.exit(0);
     });
   };


### PR DESCRIPTION
I encountered this issue in bun https://github.com/oven-sh/bun/issues/6573 and I tried using `Bun.write` instead of `process.stdout.write` then I realized that above issue does not occurs. So I replaced with Bun.write to avoid this issue and potential performance optimize since Bun.write uses faster system call than normal one.