### PR TITLE
Prevent runtime autodetection on gem require

### DIFF
--- a/lib/execjs.rb
+++ b/lib/execjs.rb
@@ -2,5 +2,7 @@ require "execjs/module"
 require "execjs/runtimes"
 
 module ExecJS
-  self.runtime ||= Runtimes.autodetect
+  def self.runtime
+    @runtime ||= Runtimes.autodetect
+  end
 end

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -5,6 +5,7 @@ require "json"
 
 begin
   require "execjs"
+  ExecJS.runtime
 rescue ExecJS::RuntimeUnavailable => e
   warn e
   exit 2


### PR DESCRIPTION
Changed the way `ExecJS.runtime` is defined so that `Runtimes.autodetect` is called only when calling `ExecJS.runtime` and not when requiring the gem itself.

## Context

For the context, we work on a Rails application named [Osuny](https://github.com/noesya/osuny) and for optimization purposes, we were working on reducing the slug size of the application image on our hosting platform Scalingo.

For this, we wanted to remove the folder containing the `node` binary as it is only used for asset compilation, and thus useless for application runtime. But removing it caused the application to fail on boot as ExecJS was trying to detect a JS runtime when starting the application.

We managed to trace back the source to the `bootstrap` gem being required, and following its dependencies, requiring `autoprefixer-rails` and then `execjs`, which in the require process, executes this line.

```
2024-10-15 13:52:36.384182752 +0200 CEST[web-1] [22] Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
2024-10-15 13:52:36.384174913 +0200 CEST[web-1] [22] ! Unable to start worker
2024-10-15 13:52:36.384183336 +0200 CEST[web-1] [22] /app/vendor/bundle/ruby/3.3.0/gems/execjs-2.9.1/lib/execjs/runtimes.rb:68:in `autodetect'
2024-10-15 13:52:36.384183680 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/execjs-2.9.1/lib/execjs.rb:5:in `<module:ExecJS>'
2024-10-15 13:52:36.384184026 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/execjs-2.9.1/lib/execjs.rb:4:in `<top (required)>'
2024-10-15 13:52:36.384184355 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
2024-10-15 13:52:36.384184668 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
2024-10-15 13:52:36.384185065 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/autoprefixer-rails-10.4.19.0/lib/autoprefixer-rails/processor.rb:4:in `<top (required)>'
2024-10-15 13:52:36.384185392 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/autoprefixer-rails-10.4.19.0/lib/autoprefixer-rails.rb:39:in `require_relative'
2024-10-15 13:52:36.384185619 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/autoprefixer-rails-10.4.19.0/lib/autoprefixer-rails.rb:39:in `<top (required)>'
2024-10-15 13:52:36.384185862 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
2024-10-15 13:52:36.384186189 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
2024-10-15 13:52:36.384186415 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/bootstrap-5.3.3/lib/bootstrap/engine.rb:3:in `<top (required)>'
2024-10-15 13:52:36.384186902 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
2024-10-15 13:52:36.384553834 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/bootstrap-5.3.3/lib/bootstrap.rb:61:in `register_rails_engine'
2024-10-15 13:52:36.384187128 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
2024-10-15 13:52:36.384555909 +0200 CEST[web-1] <internal:/app/vendor/ruby-3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
2024-10-15 13:52:36.384556483 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
2024-10-15 13:52:36.384556709 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:60:in `block (2 levels) in require'
2024-10-15 13:52:36.384556164 +0200 CEST[web-1] <internal:/app/vendor/ruby-3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
2024-10-15 13:52:36.384555317 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/bootstrap-5.3.3/lib/bootstrap.rb:11:in `load!'
2024-10-15 13:52:36.384557700 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in `each'
2024-10-15 13:52:36.384557981 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in `require'
2024-10-15 13:52:36.384559121 +0200 CEST[web-1] /app/config/environment.rb:2:in `<top (required)>'
2024-10-15 13:52:36.384555589 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/bootstrap-5.3.3/lib/bootstrap.rb:75:in `<top (required)>'
2024-10-15 13:52:36.384559412 +0200 CEST[web-1] config.ru:3:in `require_relative'
2024-10-15 13:52:36.384559665 +0200 CEST[web-1] config.ru:3:in `block (2 levels) in <top (required)>'
2024-10-15 13:52:36.384559891 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:108:in `eval'
2024-10-15 13:52:36.384558511 +0200 CEST[web-1] /app/config/application.rb:19:in `<top (required)>'
2024-10-15 13:52:36.384558896 +0200 CEST[web-1] /app/config/environment.rb:2:in `require_relative'
2024-10-15 13:52:36.384560114 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:108:in `new_from_string'
2024-10-15 13:52:36.384560905 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:97:in `load_file'
2024-10-15 13:52:36.384557169 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in `each'
2024-10-15 13:52:36.384557476 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in `block in require'
2024-10-15 13:52:36.384558290 +0200 CEST[web-1] /app/vendor/ruby-3.3.5/lib/ruby/3.3.0/bundler.rb:212:in `require'
2024-10-15 13:52:36.384561128 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:67:in `parse_file'
2024-10-15 13:52:36.384561353 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/configuration.rb:368:in `load_rackup'
2024-10-15 13:52:36.384561692 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/configuration.rb:290:in `app'
2024-10-15 13:52:36.384562086 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/runner.rb:173:in `app'
2024-10-15 13:52:36.384562726 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/runner.rb:177:in `start_server'
2024-10-15 13:52:36.384563179 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster/worker.rb:60:in `run'
2024-10-15 13:52:36.384563786 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:216:in `worker'
2024-10-15 13:52:36.384564167 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:97:in `block in spawn_worker'
2024-10-15 13:52:36.384564509 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:97:in `fork'
2024-10-15 13:52:36.384564824 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:97:in `spawn_worker'
2024-10-15 13:52:36.384565048 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:81:in `block in spawn_workers'
2024-10-15 13:52:36.384565499 +0200 CEST[web-1] <internal:numeric>:237:in `times'
2024-10-15 13:52:36.384565723 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:74:in `spawn_workers'
2024-10-15 13:52:36.384565946 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cluster.rb:430:in `run'
2024-10-15 13:52:36.384566190 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/launcher.rb:194:in `run'
2024-10-15 13:52:36.384566494 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/lib/puma/cli.rb:75:in `run'
2024-10-15 13:52:36.384566714 +0200 CEST[web-1] /app/vendor/bundle/ruby/3.3.0/gems/puma-6.4.3/bin/puma:10:in `<top (required)>'
2024-10-15 13:52:36.384566955 +0200 CEST[web-1] /app/vendor/bundle/bin/puma:27:in `load'
2024-10-15 13:52:36.384567182 +0200 CEST[web-1] /app/vendor/bundle/bin/puma:27:in `<main>'
```

That's why we proposed this change, which should not break anything but instead let ExecJS search its runtime only when necessary.