### PR TITLE
Drop obsolete `ExecJS.runtime` attr_reader

### DIFF
--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -8,8 +8,6 @@ module ExecJS
   class RuntimeUnavailable < RuntimeError; end
 
   class << self
-    attr_reader :runtime
-
     def runtime=(runtime)
       raise RuntimeUnavailable, "#{runtime.name} is unavailable on this system" unless runtime.available?
       @runtime = runtime


### PR DESCRIPTION
This `attr_reader` is redifined right after the `module.rb` is evaluated by `lib/execjs.rb`: https://github.com/rails/execjs/blob/master/lib/execjs.rb#L5-L7