### PR TITLE
fix: missing `.` in temp file which leads creating extensionless file

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -59,7 +59,7 @@ module ExecJS
         end
 
         def write_to_tempfile(contents)
-          tmpfile = create_tempfile(['execjs', 'js'])
+          tmpfile = create_tempfile(['execjs', '.js'])
           tmpfile.write(contents)
           tmpfile.close
           tmpfile


### PR DESCRIPTION
I've encountered to an situation that this issue may introduce js error depends on runtime.
Since bun runtime will default to TS/TSX if extension is missing in passed file name, then it will incorrectly parse js file as ts file (normally, this wont and should make any difference but I also found an issue in bun's transpiler that it changes code's behavior).
https://github.com/oven-sh/bun/blob/e9e93244cb3fee8bc4d734e7a4f3f2883eb1bf4a/src/bun.js/ModuleLoader.zig#L1015-L1017