### PR TITLE
ci: scope workflow token to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu:
     strategy:


### PR DESCRIPTION
Adds `permissions: contents: read` to the CI workflow. The workflow checks out the repo, installs dependencies, and runs tests - none of which need write access to repository contents or other API scopes. Pinning the token to read-only follows the principle of least privilege and limits exposure in the event of a compromised dependency or action.

More details on token permissions: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication