### PR TITLE
Include runtime stderr in error messages

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -194,36 +194,56 @@ module ExecJS
         require 'shellwords'
 
         def exec_runtime(filename)
-          command = "#{Shellwords.join(binary.split(' ') << filename)}"
-          io = IO.popen(command, **@popen_options)
-          output = io.read
-          io.close
+          stderr_path = Dir::Tmpname.create(['execjs', 'stderr']) {}
+          begin
+            command = "#{Shellwords.join(binary.split(' ') << filename)}"
+            io = IO.popen(command, err: stderr_path, **@popen_options)
+            output = io.read
+            io.close
+            status = $?
+            stderr = File.file?(stderr_path) ? File.read(stderr_path) : ""
+          ensure
+            File.unlink(stderr_path) if stderr_path && File.exist?(stderr_path)
+          end
 
-          if $?.success?
+          if status.success?
             output
           else
-            raise exec_runtime_error(output)
+            raise exec_runtime_error(output, stderr)
           end
         end
       else
         def exec_runtime(filename)
-          io = IO.popen(binary.split(' ') << filename, **@popen_options)
-          output = io.read
-          io.close
+          stderr_path = Dir::Tmpname.create(['execjs', 'stderr']) {}
+          begin
+            io = IO.popen(binary.split(' ') << filename, err: stderr_path, **@popen_options)
+            output = io.read
+            io.close
+            status = $?
+            stderr = File.file?(stderr_path) ? File.read(stderr_path) : ""
+          ensure
+            File.unlink(stderr_path) if stderr_path && File.exist?(stderr_path)
+          end
 
-          if $?.success?
+          if status.success?
             output
           else
-            raise exec_runtime_error(output)
+            raise exec_runtime_error(output, stderr)
           end
         end
       end
       # Internally exposed for Context.
       public :exec_runtime
 
-      def exec_runtime_error(output)
-        error = RuntimeError.new(output)
-        lines = output.split("\n")
+      def exec_runtime_error(output, stderr = nil)
+        message = output.to_s
+        unless stderr.nil? || stderr.empty?
+          extra = stderr.dup.force_encoding(message.encoding)
+          extra = extra.scrub if extra.respond_to?(:scrub) && !extra.valid_encoding?
+          message = message.empty? ? extra : "#{message}\n#{extra}"
+        end
+        error = RuntimeError.new(message)
+        lines = message.split("\n")
         lineno = lines[0][/:(\d+)$/, 1] if lines[0]
         lineno ||= 1
         error.set_backtrace(["(execjs):#{lineno}"] + caller)

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -67,6 +67,18 @@ class TestExecJS < Test
     end
   end
 
+  def test_runtime_error_includes_stderr
+    # Regression for #142: when the runtime exits non-zero it writes its
+    # diagnostic to stderr (here, a parse error). 5cce03a stopped capturing
+    # stderr, so the raised error lost that trace; it should be surfaced again.
+    # The diagnostic text is Node-style, so guard to Node-family runtimes.
+    skip unless ExecJS.runtime.name.to_s =~ /Node|Bun|Deno/i
+    err = assert_raises(ExecJS::RuntimeError) do
+      ExecJS.exec("?? not valid javascript ??")
+    end
+    assert err.message =~ /SyntaxError/, err.message
+  end
+
   def test_call_with_this
     # Known bug: https://github.com/cowboyd/therubyrhino/issues/39
     skip if ExecJS.runtime.is_a?(ExecJS::RubyRhinoRuntime)

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -71,8 +71,10 @@ class TestExecJS < Test
     # Regression for #142: when the runtime exits non-zero it writes its
     # diagnostic to stderr (here, a parse error). 5cce03a stopped capturing
     # stderr, so the raised error lost that trace; it should be surfaced again.
-    # The diagnostic text is Node-style, so guard to Node-family runtimes.
-    skip unless ExecJS.runtime.name.to_s =~ /Node|Bun|Deno/i
+    # The stderr-capture fix is runtime-agnostic, but the diagnostic wording
+    # varies per engine (Node says "SyntaxError", Bun differs), so this asserts
+    # on Node where the format is stable.
+    skip unless ExecJS.runtime.name.to_s =~ /Node/i
     err = assert_raises(ExecJS::RuntimeError) do
       ExecJS.exec("?? not valid javascript ??")
     end


### PR DESCRIPTION
## Summary

Fixes #142. When the external runtime exits non-zero, the diagnostic it writes to stderr (parse errors, stack traces) was being dropped, so `ExecJS::RuntimeError` carried no useful detail.

5cce03a removed the stderr-into-stdout merge to keep Bun's `.env` loading noise out of the parsed output (#130). This keeps that property: it captures stderr **separately** by redirecting the child's stderr to a temp file (a file, not a pipe, so there is no deadlock risk between draining stdout and stderr) and includes it in the error **only on the failure path**. The success path still reads stdout exactly as before, so #130 stays fixed.

`exec_runtime_error` now takes an optional `stderr` argument and is backwards compatible, so the Windows branch (which uses its own `2>&1 > file` redirect) is unaffected. The two `IO.popen` branches that 5cce03a changed (default and JRuby) are the ones updated here.

## Test

Adds `test_runtime_error_includes_stderr`, asserting a non-zero runtime exit surfaces its stderr. Full suite is green locally on MRI 2.6 + Node; the JRuby branch mirrors the same change and relies on CI.

- Before: the `ExecJS::RuntimeError` message was empty/uninformative on a runtime parse error.
- After: the message includes the runtime's stderr (for example the `SyntaxError` trace).
